### PR TITLE
Fix incorrect "location" in box.json

### DIFF
--- a/box.json
+++ b/box.json
@@ -2,7 +2,7 @@
     "name":"Masa CMS",
     "version":"7.2.0",
     "author":"We Are Orange BV",
-    "location":"https://github.com/MasaCMS/MasaCMS/archive/master.zip",
+    "location":"https://github.com/MasaCMS/MasaCMS/archive/main.zip",
     "directory":"",
     "createPackageDirectory":false,
     "packageDirectory":"",


### PR DESCRIPTION
Change the location url to reflect the fact that "master" branch has been renamed to "main" 