### PR TITLE
Update contentManager.cfc

### DIFF
--- a/core/mura/content/contentManager.cfc
+++ b/core/mura/content/contentManager.cfc
@@ -3039,7 +3039,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	</cffunction>
 
 	<cffunction name="getTabList" output="false">
-		<cfreturn "Basic,Summary,Image,Publishing,Scheduling,Layout & Objects,Categorization,Tags,Related Content,Extended Attributes,Remote">
+		<cfreturn "Basic,SEO,Summary,Image,Publishing,Scheduling,Layout & Objects,Categorization,Tags,Related Content,Extended Attributes,Remote">
 		<!--- Basic,Publishing,SEO,Mobile,List Display Options,Layout & Objects,Categorization,Tags,Related Content,Extended Attributes,Advanced,Usage Report --->
 	</cffunction>
 


### PR DESCRIPTION
When creating a new group, users inside this group can't edit SEO titles (even if group permissions are set to all)