### PR TITLE
Update database driver created by setup for MySQL/Lucee

### DIFF
--- a/core/setup/inc/doa/DBmysql_lucee.cfc
+++ b/core/setup/inc/doa/DBmysql_lucee.cfc
@@ -17,7 +17,7 @@
 			var sErr = "";
 			var sDSNServer = "jdbc:mysql://#Arguments.DatabaseServer#:#Arguments.DatabasePort#/";  //build server part of jdbc string
 			var stcA2 = StructNew();
-			var sClass = "org.gjt.mm.mysql.Driver"; //this is the driver bundled with Railo
+			var sClass = "com.mysql.cj.jdbc.Driver"; //this is the driver bundled with Railo
 			var sDSNPara ="";
 			var sDSN=""; //empty to start
 			//example


### PR DESCRIPTION
Updated the setup script that creates the DSN for MySQL/Lucee servers to include the new MySQL drivers that are packaged with modern versions of Lucee.  Current setup process fails and gives an error if you are on Lucee 5.3.  Updated to match classname of 'com.mysql.cj.jdbc.Driver'