### PR TITLE
Update filebrowser.cfc

### DIFF
--- a/core/modules/v1/filebrowser/model/beans/filebrowser.cfc
+++ b/core/modules/v1/filebrowser/model/beans/filebrowser.cfc
@@ -973,7 +973,7 @@ component
 
 		// move to getBaseResourcePath() --> getFileAssetPath()
 		var complete = (m.siteConfig('isremote') || (isdefined('arguments.completepath') && isBoolean(arguments.completepath) && arguments.completepath));
-		var preAssetPath = getBean('configBean').get('');
+		var preAssetPath = getBean('configBean').get('assetPath');
 				
 		if(len(preAssetPath)) {
 			if(arguments.resourcePath == "Site_Files") {

--- a/core/modules/v1/filebrowser/model/beans/filebrowser.cfc
+++ b/core/modules/v1/filebrowser/model/beans/filebrowser.cfc
@@ -35,7 +35,7 @@ component
 		var currentSite = application.settingsManager.getSite(arguments.siteid);
 
 		if(arguments.resourcePath == "Site_Files") {
-			pathRoot = currentSite.getAssetPath(complete=1);
+			pathRoot = currentSite.getAssetPath(complete=arguments.complete);
 		}
 		else if(arguments.resourcePath == "Application_Root") {
 			pathRoot = currentSite.getRootPath(complete=arguments.complete);
@@ -973,17 +973,21 @@ component
 
 		// move to getBaseResourcePath() --> getFileAssetPath()
 		var complete = (m.siteConfig('isremote') || (isdefined('arguments.completepath') && isBoolean(arguments.completepath) && arguments.completepath));
-		var assetPath = "";
 		var preAssetPath = getBean('configBean').get('assetPath');
-
-
+				
 		if(len(preAssetPath)) {
-			preAssetPath = preAssetPath & "/" & arguments.siteid & "/assets" & response['directory'];
-			assetPath = preAssetPath & response['directory'];
+			if(arguments.resourcePath == "Site_Files") {
+				preAssetPath = preAssetPath & "/" & arguments.siteid & response['directory'];
+			}
+			else if(arguments.resourcePath == "Application_Root") {
+				preAssetPath = response['directory'];
+			}
+			else {
+				preAssetPath = preAssetPath & "/" & arguments.siteid & "/assets" & response['directory'];		
+			}
 		}
 		else {
 			preAssetPath = getBaseResourcePath(siteid=arguments.siteid,resourcePath=arguments.resourcePath,complete=complete);
-			assetPath = preAssetPath & response['directory'];
 		}
 
 		var rsDirectory = directoryList(conditionalExpandPath(filePath),false,"query");

--- a/core/modules/v1/filebrowser/model/beans/filebrowser.cfc
+++ b/core/modules/v1/filebrowser/model/beans/filebrowser.cfc
@@ -973,7 +973,7 @@ component
 
 		// move to getBaseResourcePath() --> getFileAssetPath()
 		var complete = (m.siteConfig('isremote') || (isdefined('arguments.completepath') && isBoolean(arguments.completepath) && arguments.completepath));
-		var preAssetPath = getBean('configBean').get('assetPath');
+		var preAssetPath = getBean('configBean').get('');
 				
 		if(len(preAssetPath)) {
 			if(arguments.resourcePath == "Site_Files") {


### PR DESCRIPTION
Filebrowser had an issue with file paths in the "Site Files" and "Application Root" tabs.  "User Assets" worked just fine. 
Simple way to recreate the issue:  Navigate to the file browser > User Assets tab and navigate to a folder that contains images.  The thumbnails do not seem to work and previewing does not function properly. 
The file paths being generated were forcing an "/assets" string into the path when it was not needed.

Also removed an assetPath variable that was defined and never used.

There may be a more elegant way to fix this.