### PR TITLE
Added Category Name to Local Index Advanced Filter Field List

### DIFF
--- a/admin/core/views/cfeed/edit.cfm
+++ b/admin/core/views/cfeed/edit.cfm
@@ -121,14 +121,16 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <cfset options[19][2]="Path"/>
 <cfset options[20][1]="tcontentcategoryassign.categoryID^varchar">
 <cfset options[20][2]="Category ID"/>
-<cfset options[21][1]="tcontent.filename^varchar">
-<cfset options[21][2]="Filename"/>
+<cfset options[21][1]="tcontentcategories.name^varchar">
+<cfset options[21][2]="Category Name"/>
+<cfset options[22][1]="tcontent.filename^varchar">
+<cfset options[22][2]="Filename"/>
 
 <cfset rc.feedBean.setSiteID(rc.siteid)>
 <cfset rsExtend=application.configBean.getClassExtensionManager().getExtendedAttributeList(siteID=rc.siteid,baseTable="tcontent",activeOnly=true)>
 <cfloop query="rsExtend">
-<cfset options[rsExtend.currentRow + 20][1]="#rsExtend.attributeID#^varchar">
-<cfset options[rsExtend.currentRow + 20][2]="#rsExtend.Type#/#rsExtend.subType# - #rsExtend.attribute#"/>
+<cfset options[rsExtend.currentRow + 22][1]="#rsExtend.attributeID#^varchar">
+<cfset options[rsExtend.currentRow + 22][2]="#rsExtend.Type#/#rsExtend.subType# - #rsExtend.attribute#"/>
 </cfloop>
 
 <cfset criterias[1][1]="Equals">


### PR DESCRIPTION
This fix also restores 'Filename' as an option in Field list as it was being overwritten by the first class extension field. 

Fixes issue #214 