### PR TITLE
Fixed #230 Related Content Advanced Search

### DIFF
--- a/admin/assets/js/architecture.js
+++ b/admin/assets/js/architecture.js
@@ -973,7 +973,7 @@ This file is part of Mura CMS.
 					var valueSelector = '#internalContent input';
 					// if doing an advanced search, then serialze all elements, except the hidden inputs.
 					if (advSearching) {
-						valueSelector = '#selectRelatedContent input:not([type=hidden]), #selectRelatedContent select';
+						valueSelector = '#selectRelatedContent input:not([type=hidden]):not([name=entitytype]), #selectRelatedContent select';
 					}
 					$('#mura-rc-quickedit').hide();
 					siteManager.loadRelatedContent(contentid,siteid, 0, $(valueSelector).serialize(), advSearching,external,relatedcontentsetid);


### PR DESCRIPTION
Fixed Related Content Advanced Search by not passing entitytype to siteManager.loadRelatedContent - this param is appended by the next function downstream.