### PR TITLE
cArch.edit: Extend default view loading process

### DIFF
--- a/admin/core/views/carch/edit.cfm
+++ b/admin/core/views/carch/edit.cfm
@@ -1,34 +1,34 @@
-<!---
-This file is part of Masa CMS. Masa CMS is based on Mura CMS, and adopts the
-same licensing model. It is, therefore, licensed under the Gnu General Public License
-version 2 only, (GPLv2) subject to the same special exception that appears in the licensing
-notice set out below. That exception is also granted by the copyright holders of Masa CMS
-also applies to this file and Masa CMS in general.
+<!--- 
+This file is part of Masa CMS. Masa CMS is based on Mura CMS, and adopts the  
+same licensing model. It is, therefore, licensed under the Gnu General Public License 
+version 2 only, (GPLv2) subject to the same special exception that appears in the licensing 
+notice set out below. That exception is also granted by the copyright holders of Masa CMS 
+also applies to this file and Masa CMS in general. 
 
-This file has been modified from the original version received from Mura CMS. The
+This file has been modified from the original version received from Mura CMS. The 
 change was made on: 2021-07-27
-Although this file is based on Mura™ CMS, Masa CMS is not associated with the copyright
-holders or developers of Mura™CMS, and the use of the terms Mura™ and Mura™CMS are retained
-only to ensure software compatibility, and compliance with the terms of the GPLv2 and
-the exception set out below. That use is not intended to suggest any commercial relationship
-or endorsement of Mura™CMS by Masa CMS or its developers, copyright holders or sponsors or visa versa.
+Although this file is based on Mura™ CMS, Masa CMS is not associated with the copyright 
+holders or developers of Mura™CMS, and the use of the terms Mura™ and Mura™CMS are retained 
+only to ensure software compatibility, and compliance with the terms of the GPLv2 and 
+the exception set out below. That use is not intended to suggest any commercial relationship 
+or endorsement of Mura™CMS by Masa CMS or its developers, copyright holders or sponsors or visa versa. 
 
 If you want an original copy of Mura™ CMS please go to murasoftware.com .  
-For more information about the unaffiliated Masa CMS, please go to masacms.com
+For more information about the unaffiliated Masa CMS, please go to masacms.com  
 
-Masa CMS is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, Version 2 of the License.
-Masa CMS is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+Masa CMS is free software: you can redistribute it and/or modify 
+it under the terms of the GNU General Public License as published by 
+the Free Software Foundation, Version 2 of the License. 
+Masa CMS is distributed in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+GNU General Public License for more details. 
 
-You should have received a copy of the GNU General Public License
-along with Masa CMS. If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License 
+along with Masa CMS. If not, see <http://www.gnu.org/licenses/>. 
 
-The original complete licensing notice from the Mura CMS version of this file is as
-follows:
+The original complete licensing notice from the Mura CMS version of this file is as 
+follows: 
 
 This file is part of Mura CMS.
 
@@ -261,9 +261,9 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	<script type="text/javascript">
 		var hasSummary=#subType.getHasSummary()#;
 		var hasBody=#subType.getHasBody()#;
-		var extendSetCount=#arrayLen(subtype.getExtendSets())#
 	</script>
 </cfoutput>
+
 
 
 <script type="text/javascript">
@@ -306,14 +306,6 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 				$('##editDates').show();
 			</cfif>
 		}, 500);
-
-		// trigger if body is hidden, but there are extend sets
-		<cfelse>
-		if (hasBody===0 && extendSetCount>0) {
-			setTimeout(function(){
-				$('##bigui__extended').show();
-			}, 500);
-		}
 		</cfif>
 		</cfoutput>
 

--- a/admin/core/views/carch/edit.cfm
+++ b/admin/core/views/carch/edit.cfm
@@ -1,34 +1,34 @@
-<!--- 
-This file is part of Masa CMS. Masa CMS is based on Mura CMS, and adopts the  
-same licensing model. It is, therefore, licensed under the Gnu General Public License 
-version 2 only, (GPLv2) subject to the same special exception that appears in the licensing 
-notice set out below. That exception is also granted by the copyright holders of Masa CMS 
-also applies to this file and Masa CMS in general. 
+<!---
+This file is part of Masa CMS. Masa CMS is based on Mura CMS, and adopts the
+same licensing model. It is, therefore, licensed under the Gnu General Public License
+version 2 only, (GPLv2) subject to the same special exception that appears in the licensing
+notice set out below. That exception is also granted by the copyright holders of Masa CMS
+also applies to this file and Masa CMS in general.
 
-This file has been modified from the original version received from Mura CMS. The 
+This file has been modified from the original version received from Mura CMS. The
 change was made on: 2021-07-27
-Although this file is based on Mura™ CMS, Masa CMS is not associated with the copyright 
-holders or developers of Mura™CMS, and the use of the terms Mura™ and Mura™CMS are retained 
-only to ensure software compatibility, and compliance with the terms of the GPLv2 and 
-the exception set out below. That use is not intended to suggest any commercial relationship 
-or endorsement of Mura™CMS by Masa CMS or its developers, copyright holders or sponsors or visa versa. 
+Although this file is based on Mura™ CMS, Masa CMS is not associated with the copyright
+holders or developers of Mura™CMS, and the use of the terms Mura™ and Mura™CMS are retained
+only to ensure software compatibility, and compliance with the terms of the GPLv2 and
+the exception set out below. That use is not intended to suggest any commercial relationship
+or endorsement of Mura™CMS by Masa CMS or its developers, copyright holders or sponsors or visa versa.
 
 If you want an original copy of Mura™ CMS please go to murasoftware.com .  
-For more information about the unaffiliated Masa CMS, please go to masacms.com  
+For more information about the unaffiliated Masa CMS, please go to masacms.com
 
-Masa CMS is free software: you can redistribute it and/or modify 
-it under the terms of the GNU General Public License as published by 
-the Free Software Foundation, Version 2 of the License. 
-Masa CMS is distributed in the hope that it will be useful, 
-but WITHOUT ANY WARRANTY; without even the implied warranty of 
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
-GNU General Public License for more details. 
+Masa CMS is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, Version 2 of the License.
+Masa CMS is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License 
-along with Masa CMS. If not, see <http://www.gnu.org/licenses/>. 
+You should have received a copy of the GNU General Public License
+along with Masa CMS. If not, see <http://www.gnu.org/licenses/>.
 
-The original complete licensing notice from the Mura CMS version of this file is as 
-follows: 
+The original complete licensing notice from the Mura CMS version of this file is as
+follows:
 
 This file is part of Mura CMS.
 
@@ -261,9 +261,9 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	<script type="text/javascript">
 		var hasSummary=#subType.getHasSummary()#;
 		var hasBody=#subType.getHasBody()#;
+		var extendSetCount=#arrayLen(subtype.getExtendSets())#
 	</script>
 </cfoutput>
-
 
 
 <script type="text/javascript">
@@ -306,6 +306,14 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 				$('##editDates').show();
 			</cfif>
 		}, 500);
+
+		// trigger if body is hidden, but there are extend sets
+		<cfelse>
+		if (hasBody===0 && extendSetCount>0) {
+			setTimeout(function(){
+				$('##bigui__extended').show();
+			}, 500);
+		}
 		</cfif>
 		</cfoutput>
 

--- a/admin/core/views/carch/edit.cfm
+++ b/admin/core/views/carch/edit.cfm
@@ -261,6 +261,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	<script type="text/javascript">
 		var hasSummary=#subType.getHasSummary()#;
 		var hasBody=#subType.getHasBody()#;
+		var extendSetCount=#arrayLen(subtype.getExtendSets())#;
 	</script>
 </cfoutput>
 
@@ -306,6 +307,14 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 				$('##editDates').show();
 			</cfif>
 		}, 500);
+
+		// trigger if body is hidden, but there are extend sets
+		<cfelse>
+		if (hasBody===0 && extendSetCount>0) {
+			setTimeout(function(){
+				$('##bigui__extended').show();
+			}, 500);
+		}
 		</cfif>
 		</cfoutput>
 


### PR DESCRIPTION
If for a subtype "Body" and "Summary" are hidden, but there are Extended Attributes, show the page "Extended Attributes" on page load instead.