### PR TITLE
ApiUtility - component not found on upgrade. Needs to be uppercase A

### DIFF
--- a/core/mura/settings/settingsBean.cfc
+++ b/core/mura/settings/settingsBean.cfc
@@ -1247,7 +1247,7 @@ component extends="mura.bean.beanExtendable" entityName="site" table="tsettings"
 
 	public function getApi(type="json", version="v1") output=false {
 		if ( !isDefined('variables.instance.api#arguments.type##arguments.version#') ) {
-			variables.instance['api#arguments.type##arguments.version#']=evaluate('new mura.client.api.#arguments.type#.#arguments.version#.#arguments.type#apiUtility(siteid=getValue("siteid"))');
+			variables.instance['api#arguments.type##arguments.version#']=evaluate('new mura.client.api.#arguments.type#.#arguments.version#.#arguments.type#ApiUtility(siteid=getValue("siteid"))');
 		}
 		return variables.instance['api#arguments.type##arguments.version#'];
 	}


### PR DESCRIPTION
Upgrading to 7.4.5 from 7.4.5 causes apiUtility not to be found on CF2021. Issue is  

They basically changed it by adding #arguments.type#apiUtility(siteid=.... (edited) 

which evaluated to the file jsonapiUtility.cfc.....

BUT the file is jsonApiUtility.cfc

it worked with original because the file was apiUtility (lowercase 'a') they added the type to the filename and renamed the file but in doing so made the a uppercase