### PR TITLE
add check for "x-https" header in utility.getRequestProtocol()

### DIFF
--- a/core/mura/utility.cfc
+++ b/core/mura/utility.cfc
@@ -423,8 +423,10 @@ This file is part of Mura CMS.
 		    <cfreturn "https">
 		<cfelseif StructKeyExists(headers,"Front-End-Https") and isBoolean(headers["Front-End-Https"]) and headers["Front-End-Https"]>
 			<cfreturn "https">
+		<cfelseif StructKeyExists(headers,"x-https") and isBoolean(headers["x-https"]) and headers["x-https"]>
+			<cfreturn "https">
 		<cfelse>
-		    <cfreturn getPageContext().getRequest().getScheme()>
+			<cfreturn getPageContext().getRequest().getScheme()>
 		</cfif>
 
 		<cfcatch>


### PR DESCRIPTION
Ran into an issue with a site hosted on Viviotech where the only proxy header to determine the actual protocol was to check for the `x-https` header.