### PR TITLE
Could not view Form data when using eurodate formats

### DIFF
--- a/admin/core/views/carch/data_manager/dsp_response.cfm
+++ b/admin/core/views/carch/data_manager/dsp_response.cfm
@@ -101,14 +101,14 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 
 	<div class="mura-control-group">
   	<label>#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.from')#</label>
-  	<input type="text" class="datepicker" name="date1"  validate="date" message="#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.tovalidate')#" required="true" value="#LSDateFormat(rc.date1,session.dateKeyFormat)#">
+  	<input type="text" class="datepicker" name="date1"  validate="onServer" message="#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.tovalidate')#" required="true" value="#LSDateFormat(rc.date1,session.dateKeyFormat)#">
   	<select name="hour1" class="time"><cfloop from="0"to="23" index="h"><option value="#h#" <cfif hour(rc.rsDataInfo.firstentered) eq h>selected</cfif>><cfif h eq 0>12 AM<cfelseif h lt 12>#iif(len(h) lt 2,de('0#h#'),de('#h#'))# AM<cfelseif h eq 12>#iif(len(h) lt 2,de('0#h#'),de('#h#'))# PM<cfelse><cfset h2=h-12>#iif(len(h2) lt 2,de('0#h2#'),de('#h2#'))# PM</cfif></option></cfloop></select>
     <select name="minute1" class="time"><cfloop from="0"to="59" index="mn"><option value="#mn#" <cfif minute(rc.rsDataInfo.firstentered) eq mn>selected</cfif>>#iif(len(mn) lt 2,de('0#mn#'),de('#mn#'))#</option></cfloop></select>
 	</div>
 
 	<div class="mura-control-group">
   	<label>#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.to')#</label>
-  	<input type="text" class="datepicker" name="date2" validate="date" message="#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.tovalidate')#" required="true" value="#LSDateFormat(rc.date2,session.dateKeyFormat)#">
+  	<input type="text" class="datepicker" name="date2" validate="onServer" message="#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.tovalidate')#" required="true" value="#LSDateFormat(rc.date2,session.dateKeyFormat)#">
   	<select name="hour2" class="time"><cfloop from="0"to="23" index="h"><option value="#h#" <cfif hour(rc.rsDataInfo.Lastentered) eq h>selected</cfif>><cfif h eq 0>12 AM<cfelseif h lt 12>#iif(len(h) lt 2,de('0#h#'),de('#h#'))# AM<cfelseif h eq 12>#iif(len(h) lt 2,de('0#h#'),de('#h#'))# PM<cfelse><cfset h2=h-12>#iif(len(h2) lt 2,de('0#h2#'),de('#h2#'))# PM</cfif></option></cfloop></select>
     <select name="minute2" class="time" ><cfloop from="0"to="59" index="mn"><option value="#mn#" <cfif minute(rc.rsDataInfo.lastentered) eq mn>selected</cfif>>#iif(len(mn) lt 2,de('0#mn#'),de('#mn#'))#</option></cfloop>
    </select>


### PR DESCRIPTION
## What?
Could not view Form data when using eurodate formats

## The bug finding
### The form
*wwwroot\\admin\\core\\views\\carch\\data_manager\\dsp_response.cfm:168*
```html
<div class="mura-actions">
	<div class="form-actions">
		<button type="button" class="btn mura-primary" onclick="submitForm(document.forms.download);" />
			<i class="mi-bar-chart">
			</i> #application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.viewdata')#</button>
		<cfset downloadLocationString="'./?muraAction=cArch.downloaddata&siteid=#esapiEncode('url',rc.siteid)#&contentid=#esapiEncode('url',rc.contentid)#&date1=' + document.download.date1.value + '&hour1=' +document.download.hour1.value + '&minute1=' +document.download.minute1.value + '&date2=' + document.download.date2.value + '&hour2=' + document.download.hour2.value + '&minute2=' + document.download.minute2.value + '&sortBy=' +  document.download.sortBy.value + '&sortDirection=' +  document.download.sortDirection.value + '&filterBy='  + document.download.filterBy.value + '&keywords=' + document.download.keywords.value + '&columns=#esapiEncode('url',rc.columns)#'">
		<cfif isdefined ('rc.minute1')>
			<button type="button" class="btn" onclick="return confirmDialog('Delete filtered results?',function(){document.download.delete.value=1;submitForm(document.forms.download);});" />
			<i class="mi-trash">
			</i> Delete Results</button>
			</cfif>
		<button type="button" class="btn" onclick="location.href=#downloadLocationString#;">
			<i class="mi-download">
			</i> #application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.download')#</button>
	</div>
</div>
```
### Date Validation
*wwwroot\\admin\\core\\views\\carch\\data_manager\\dsp_response.cfm:104,121*
```xml
<input type="text" class="datepicker" name="date1"  validate="date"
message=
	   "#
		application.rbFactory.getKeyValue(
		session.rb,'sitemanager.content.fields.tovalidate'
		)#" required="true"
		value="#LSDateFormat(rc.date1,session.dateKeyFormat)
		#"
>
```

# FIX FOUND
changed line at *admin\\core\\views\\carch\\data_manager\\dsp_response.cfm:102,121* To allow any date format instead of only US. Changed validate from `date` to `onServer`

> If validateAt="onServer", allows any date format that returns true in the IsDate function; otherwise, same as USdate.

[Adobe Docs](https://helpx.adobe.com/coldfusion/cfml-reference/coldfusion-tags/tags-i/cfinput.html)
```xml
<input type="text" class="datepicker" name="date2" validate="onServer" message="#application.rbFactory.getKeyValue(session.rb,'sitemanager.content.fields.tovalidate')#" required="true" value="#LSDateFormat(rc.date2,session.dateKeyFormat)#">
```