### PR TITLE
ETR - File Browser Update

### DIFF
--- a/admin/assets/js/filebrowser/assets/css/filebrowser.css
+++ b/admin/assets/js/filebrowser/assets/css/filebrowser.css
@@ -144,7 +144,7 @@
 
 #actionwindow-wrapper {
   position: absolute;
-  margin: 60px 30%;
+  margin: 30px 30px;
   background-color: #ffffff;
   z-index: 100000;
 }
@@ -152,7 +152,7 @@
 .actionwindow-formwrapper {
   height: auto;
   min-height: 205px;
-  min-width: 450px;
+  min-width: 650px;
 }
 
 .actionwindow-formwrapper .editwindow {

--- a/admin/assets/js/filebrowser/assets/css/filebrowser.css
+++ b/admin/assets/js/filebrowser/assets/css/filebrowser.css
@@ -144,7 +144,7 @@
 
 #actionwindow-wrapper {
   position: absolute;
-  margin: 30px 30px;
+  margin: 60px 30%;
   background-color: #ffffff;
   z-index: 100000;
 }

--- a/admin/assets/js/filebrowser/filebrowser.js
+++ b/admin/assets/js/filebrowser/filebrowser.js
@@ -2029,7 +2029,7 @@ MuraFileBrowser = {
 				return false;
 			}
 			, checkFileEditable: function() {
-			var editlist = this.settings.editfilelist;
+			var editlist = this.settings.editfilelist.split(",");
 	
 			for(var i = 0;i<editlist.length;i++) {
 				if(this.currentFile.ext.toLowerCase() == editlist[i]) {
@@ -2039,7 +2039,7 @@ MuraFileBrowser = {
 			return false;
 			}
 			, checkImageType: function() {
-			var imagelist = this.settings.imagelist;
+			var imagelist = this.settings.imagelist.split(",");
 				for(var i = 0;i<imagelist.length;i++) {
 				if(this.currentFile.ext.toLowerCase() == imagelist[i]) {
 					return true;

--- a/admin/assets/js/filebrowser/filebrowser.js
+++ b/admin/assets/js/filebrowser/filebrowser.js
@@ -2014,8 +2014,8 @@ MuraFileBrowser = {
 			return MuraFileBrowser.config.selectMode;
 			}
 			, isViewable: function() {
-				var editlist = this.settings.editfilelist;
-				var imagelist = this.settings.imagelist;
+				var editlist = this.settings.editfilelist.split(",");
+				var imagelist = this.settings.imagelist.split(",");
 				for(var i = 0;i<editlist.length;i++) {
 				if(this.currentFile.ext.toLowerCase() == editlist[i]) {
 					return true;


### PR DESCRIPTION
These functions in the FileBrowser / FileViewer are attempting to iterate over the file and image extensions that the user defines in the settings.ini.cfm as filebrowsereditlist etc. However, the iteration is happening over a string.

This image illustrates the issue. Note the "t" in the debug popup where it should be comparing against a whole extension (txt for example).
![image](https://github.com/MasaCMS/MasaCMS/assets/65236778/81f1689a-96e6-451e-95ca-9438a4e7f14e)

I also updated the CSS to fix the Edit window being cut in half and right justified on the page. 
![image](https://github.com/MasaCMS/MasaCMS/assets/65236778/b90d231e-347b-4439-9f0c-c6d110fdff54)

**Note** I made this change in a non-minified JS file. If you need me to minify it or make any updates, I can do that as well. I did test that this resolves the issues.
