### PR TITLE
Update filebrowser.js

### DIFF
--- a/admin/assets/js/filebrowser/filebrowser.js
+++ b/admin/assets/js/filebrowser/filebrowser.js
@@ -1265,8 +1265,8 @@ MuraFileBrowser = {
 			var fdata = {
 				displaymode: JSON.parse(JSON.stringify(mode))
 			}
-	
-			Mura.createCookie( 'fbDisplayMode',JSON.stringify(fdata),1000);
+			// URL encodes the JSON string to safely handle special characters in the cookie value
+			Mura.createCookie( 'fbDisplayMode',encodeURIComponent(JSON.stringify(fdata)),1000);
 	
 			this.$root.displaymode = this.viewmode = mode;
 			}
@@ -2083,8 +2083,9 @@ MuraFileBrowser = {
 			var cDisplay = Mura.readCookie( 'fbDisplayMode' );
 	
 			if(cDisplay) {
-				var fbDisplayJSON = JSON.parse(cDisplay);
-	
+				var decodedDisplay = decodeURIComponent(cDisplay);
+		        var fbDisplayJSON = JSON.parse(decodedDisplay);
+        
 				if(fbDisplayJSON.displaymode)
 				this.$root.displaymode = this.viewmode = fbDisplayJSON.displaymode;
 	


### PR DESCRIPTION
This fixes an issue where Tomcat refuses to use a Masa cookie because of special characters. URL Encoding / Decoding the cookie resolves it. ```19-Jul-2024 14:10:11.406 INFO [http-nio-8888-exec-1] org.apache.tomcat.util.http.parser.Cookie.logInvalidHeader A cookie header was received [fbDisplayMode={"displaymode":1}] that contained an invalid cookie. That cookie will be ignored.```

This isn't a big issue but helps keep things working as intended and the logs clean. 