### PR TITLE
Defer module.js to avoid blocking page rendering

### DIFF
--- a/core/modules/v1/gatedasset/model/handlers/handler.cfc
+++ b/core/modules/v1/gatedasset/model/handlers/handler.cfc
@@ -1,7 +1,7 @@
 component extends='mura.cfobject' {
  
   function onRenderStart(m) {
-    arguments.m.addToHTMLFootQueue('<script src="/core/modules/v1/gatedasset/assets/js/module.js"></script>');
+    arguments.m.addToHTMLFootQueue('<script #m.getMuraJSDeferredString()# src="/core/modules/v1/gatedasset/assets/js/module.js"></script>');
   }
  
   function onGatedAssetSuccess(m) {


### PR DESCRIPTION
Lighthouse and WebPageTest.org recommend using "defer" when loading external <script> files, to avoid blocking page rendering.

This change turns on the "defer" attribute for module.js, if the user has this.deferMuraJS=true; in their contentRenderer.cfc file.