### PR TITLE
Make tagFilter configurable in settings.ini.cfm

### DIFF
--- a/core/mura/Portcullis.cfc
+++ b/core/mura/Portcullis.cfc
@@ -53,7 +53,7 @@
 	<cfset variables.instance.blockCRLF = false/>									<!---Block CRLF (carriage return line feed) hacks, this particular hack has limited abilities so this could be overkill--->
 
 	<cfset variables.instance.sqlFilter = "select,insert,update,delete,create,drop,alter,declare,execute,--,xp_,sp_sqlexecute,table_cursor,cast\(,exec\(,eval\(,information_schema"/>
-	<cfset variables.instance.tagFilter = "script,object,applet,embed,form,input,layer,ilayer,frame,iframe,frameset,param,meta,base,style,xss,marquee"/>
+	<cfset variables.instance.tagFilter = application.configBean.gettagFilter()/>
 	<cfset variables.instance.wordFilter = "qss,onError,onEvent,onLoad,onClick,onDblClick,onKeyDown,onKeyPress,onKeyUp,onMouseDown,onMouseOut,onMouseUp,onMouseOver,onBlur,onChange,onFocus,onSelect,javascript:,vbscript:,\.cookie,\.toString,:expr,:expression,\.fromCharCode,String\."/>
 
 	<cfset variables.instance.thisServer = lcase(CGI.SERVER_NAME)/>

--- a/core/mura/configBean.cfc
+++ b/core/mura/configBean.cfc
@@ -236,6 +236,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 <cfset variables.instance.filemanagerEnabled=true>
 <cfset variables.instance.deprecationwarningsenabled=true>
 <cfset variables.instance.deprecationlogfile="deprecations">
+<cfset variables.instance.tagFilter="script,object,applet,embed,form,input,layer,ilayer,frame,iframe,frameset,param,meta,base,style,xss,marquee">
 
 <cffunction name="OnMissingMethod" output="false" hint="Handles missing method exceptions.">
 <cfargument name="MissingMethodName" type="string" required="true" hint="The name of the missing method." />
@@ -2146,6 +2147,10 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 	</cfif>
 
 	<cfreturn variables.instance.version>
+
+	<cffunction name="getTagFilter" output="false">
+		<cfreturn variables.instance.tagFilter />
+	</cffunction>
 </cffunction>
 
 <cfscript>


### PR DESCRIPTION
This pull request implements the feature discussed in #333.

The argument does not seem to be created in `settings.ini.cfm` by default however the defaults are still being enforced. Idk If it is needed to add this to the `settings.ini.cfm` default.

_Ori :3_