### PR TITLE
Fix Shadowbox styling and functionality issues

### DIFF
--- a/core/modules/v1/collection/layout/index.cfm
+++ b/core/modules/v1/collection/layout/index.cfm
@@ -75,6 +75,7 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 --->
 <cfsilent>
 <cfparam name="objectParams.maxitems" default="4">
+<cfparam name="objectParams.sourcetype" default="">
 <cfparam name="objectParams.source" default="">
 <cfparam name="objectParams.layout" default="default">
 <cfparam name="objectParams.forcelayout" default="false">

--- a/core/modules/v1/core_assets/js/shadowbox.js
+++ b/core/modules/v1/core_assets/js/shadowbox.js
@@ -42,7 +42,7 @@
       */
      getStyle: function(el, style){
          //console.log(style + ': ' +  Mura(el).css(style))
-         return Mura(el).css(style);
+         return Mura(el).css(style)||"0";
      },
 
      /**
@@ -453,11 +453,14 @@
 
             loading:    'Loading',
 
-            close:      '<span class="shortcut">C</span>lose',
+            //close:      '<span class="shortcut">C</span>lose',
+            close:     '×', 
 
-            next:       '<span class="shortcut">N</span>ext',
+            //next:       '<span class="shortcut">N</span>ext',
+            next:      '⏵', 
 
-            prev:       '<span class="shortcut">P</span>revious',
+            //prev:       '<span class="shortcut">P</span>revious',
+            prev:      '⏴',
 
             errors:     {
                 single: 'You must install the <a href="{0}">{1}</a> browser plugin to view this content.',
@@ -1277,7 +1280,7 @@
                     counter += '>' + (i + 1) + '</a>';
                 }
             }else{
-                counter = (current + 1) + ' of ' + current_gallery.length;
+                counter = (current + 1) + ' / ' + current_gallery.length;
             }
             appendHTML(tool_i, String.format(options.skin.counter, counter));
         }


### PR DESCRIPTION
Ensure getStyle function returns "0" for undefined styles, preventing errors in some browsers like chrome.
Replace text controls with symbols to avoid translation needs.