### PR TITLE
Register global module- and content_type-directories for all siteIDs

### DIFF
--- a/core/mura/settings/settingsManager.cfc
+++ b/core/mura/settings/settingsManager.cfc
@@ -526,6 +526,8 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 					.set('contentTypeLookUpArray',duplicate(siteTemplate.get('contentTypeLookUpArray')))
 					.discoverContentTypes()>
 
+				<cfset builtSites['#rs.siteid#'].discoverGlobalModules()>
+				<cfset builtSites['#rs.siteid#'].discoverGlobalContentTypes()>
 				<cfset builtSites['#rs.siteid#'].discoverBeans()>
 				<cfset commitTracepoint(tracepoint2)>
 			</cfif>


### PR DESCRIPTION
### What did I do?

1. I created a new module using the following structure:

```
/modules
    /my_module
        /content_types
            /page_default
                /index.cfm - you can dump a timestamp for testing purposes
```

2. I created multiple sites in a single Masa CMS instance: default, sitea and siteb

### What error did I encounter?

The content-type template was not registered for my sitea and siteb.

### How did I fix the error?

I added an invokation of `discoverGlobalModules()` and `discoverGlobalContentTypes()` in addition to the already existing `discoverBeans()`.

### Downsides

This might increase appreload times.