### PR TITLE
Set correct oderNo when inserting content with topOrBottom set to "bottom"

### DIFF
--- a/core/mura/content/contentManager.cfc
+++ b/core/mura/content/contentManager.cfc
@@ -1562,9 +1562,10 @@ version 2 without this exception.  You may, if you choose, apply this exception 
 						 select max(orderno) as theBottom from tcontent where parentid=<cfqueryparam cfsqltype="cf_sql_varchar" value="#newBean.getparentid()#">
 						 and siteid=<cfqueryparam cfsqltype="cf_sql_varchar" value="#newBean.getsiteid()#">
 						 and type in ('Page','Folder','Link','File','Component','Calendar','Form') and active=1
+						 and contentid <> <cfqueryparam cfsqltype="cf_sql_varchar" value="#newBean.getcontentid()#">
 						 </cfquery>
 
-						<cfif isNumeric(rsOrder.theBottom) and rsOrder.theBottom neq newBean.getOrderNo()>
+						<cfif isNumeric(rsOrder.theBottom)>
 							<cfset newBean.setOrderNo(rsOrder.theBottom + 1) >
 						<cfelse>
 							<cfset newBean.setOrderNo(1) >


### PR DESCRIPTION
### What did I do?

1. I created a new module using the following structure:

```
/modules
    /my_module
        /model
            /handlers
                /eventHandler.cfc
```

*eventHandler.cfc*

```
component extends="mura.cfobject" {

	/**
	 * @hint Sets the orderNo on newly generated content blocks
	 */
	public void function onBeforeContentSave(m) output=false {
		if (arguments.m.content().getIsNew()) {
			arguments.m.content().set("topOrBottom", "bottom");
		}
	}

}
```

### What error did I encounter?

The `orderNo` of the newly generated content was always 1.

This happens because when topOrBottom is set to "bottom", the highest `orderNo` is retreived from the database. The new content (at this time has `orderNo` set to 1) only gets its `orderNo` updated, when `rsOrder.theBottom` is not a numeric or when it's not equal the `orderNo` of the newly generated content bean.

This creates following scenarios:
- No content in the parent yet, `rsOrder.theBottom` is empty, therefore `orderNo` is set to 1
- Only one content in the parent, `rsOrder.theBottom` is 1, so it is equal to the current bean's `orderNo`, therefore `orderNo` is set to 1 *this is where the current approach is wrong*
- Two or more contents in the parent, `rsOrder.theBottom` is 2 or higher, therefore `orderNo` is set to the current max + 1

### How did I fix the error?

1. I changed the query `rsOrder` to exclude the current content, so whenever the current content is already the highest, it will not unneccessarily increase its orderNo by one.
2. I changed the condition to check if `rsOrder.theBottom` is not equal to the current bean's `orderNo` to only check wether it is a numeric or not.

This creates following scenarios: 
- (same as before) No content in the parent yet, `rsOrder.theBottom` is empty, therefore `orderNo` is set to 1
- Only one content in the parent, `rsOrder.theBottom` is 1, therefore `orderNo` is set to the current max + 1 *this works correctly now*
- (same as before) Two or more contents in the parent, `rsOrder.theBottom` is 2 or higher, therefore `orderNo` is set to the current max + 1